### PR TITLE
fix(unix): match int types for artihmetic with CGO

### DIFF
--- a/du_unix.go
+++ b/du_unix.go
@@ -10,9 +10,9 @@ func getUsage(path string) (Info, error) {
 	var stat syscall.Statfs_t
 	err := syscall.Statfs(path, &stat)
 	i := Info{
-		Total:     stat.Bsize * int64(stat.Blocks),
-		Available: stat.Bsize * int64(stat.Bavail),
-		Free:      stat.Bsize * int64(stat.Bfree),
+		Total:     int64(stat.Bsize) * int64(stat.Blocks),
+		Available: int64(stat.Bsize) * int64(stat.Bavail),
+		Free:      int64(stat.Bsize) * int64(stat.Bfree),
 	}
 	return i, err
 }


### PR DESCRIPTION
Fix error 'mismatched types int32 and int64' when building with CGO_ENABLED=1